### PR TITLE
Adding favicon with the new logo

### DIFF
--- a/webapp/templates/layout.jinja
+++ b/webapp/templates/layout.jinja
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/>
   <meta name="theme-color" content="#ffffff"/>
+  <link rel="icon" href="{{ url_for('static', filename='logo.svg') }}"/>
   <link rel="stylesheet"
         href="{{ url_for('static', filename='css/bootstrap.min.css') }}"/>
   {% if request.endpoint == 'views.task' and highlight_syntax %}


### PR DESCRIPTION
The new logo was added to the website but seems like the favicon was forgotten. Let DTA stay recognizable from the plenty of opened tabs.