### PR TITLE
Разработка функциональности автоматического обновления статуса задачи в ЦАП

### DIFF
--- a/webapp/dto.py
+++ b/webapp/dto.py
@@ -170,6 +170,16 @@ class TaskStatusDto:
             Status.CheckedFailed: True,
         })
 
+    @property
+    def is_submitted(self) -> bool:
+        if self.status in [Status.Submitted, Status.CheckedSubmitted]:
+            return True
+        if self.status in [Status.Checked, Status.Failed, Status.NotSubmitted, Status.CheckedFailed]:
+            return False
+        else:
+            assert False, "unhandled status"
+            return False
+
     def map_achievements(self, status: TaskStatus | None, achievements: list[int]):
         dtos = []
         for order, count in enumerate(achievements):

--- a/webapp/static/js/autoreload.js
+++ b/webapp/static/js/autoreload.js
@@ -1,0 +1,13 @@
+let statusPath = window.location.href + "/status";
+let f = () => fetch(statusPath).then(res => {
+	if(res.status == 418) {
+		return new Promise(r => setTimeout(r, 2000)).then(f)
+	}
+	if(!res.ok) {
+		return
+	}
+	return res.text().then(b => {
+		document.getElementById("task-status").innerHTML = b;
+	})
+});
+f()

--- a/webapp/templates/student/task.jinja
+++ b/webapp/templates/student/task.jinja
@@ -29,6 +29,9 @@
   </a>
 </div>
 
+{% if status.status == 0 or status.status == 5 %}
+<script src="/static/js/autoreload.js"></script>
+{% endif %}
 <div id="task-status">
 {% include 'student/task_status.jinja' %}
 </div>

--- a/webapp/templates/student/task.jinja
+++ b/webapp/templates/student/task.jinja
@@ -29,7 +29,7 @@
   </a>
 </div>
 
-{% if status.status == 0 or status.status == 5 %}
+{% if status.is_submitted %}
 <script src="/static/js/autoreload.js"></script>
 {% endif %}
 <div id="task-status">

--- a/webapp/templates/student/task.jinja
+++ b/webapp/templates/student/task.jinja
@@ -28,48 +28,9 @@
     status.external.group_title }}
   </a>
 </div>
-<div>
-  <h6 class="card-title fw-bold">
-    Состояние задачи
-  </h6>
-  <h6 class="card-subtitle mb-2 text-muted">
-    В данной секции Вы можете отслеживать состояние задания после отправки решения.
-  </h6>
-  {% if status.status == 4 %}
-  {% else %}
-  <div class="badge alert-{{ status.color }} mt-2 mb-2" style="font-size: inherit">
-    {{ status.name }}
-  </div>
-  {% if status.error_message is not none and status.error_message and (not registration or student) %}
-  <div>Подробные сведения об ошибке:</div>
-  <div class="text-muted mb-2" style="white-space: pre-wrap">{{ status.error_message | e }}</div>
-  {% else %}
-  <div class="mb-2"></div>
-  {% endif %}
-  {% endif %}
-</div>
-{% if status.show_achievements %}
-<div>
-  <h6 class="card-title fw-bold">
-    Разблокированные достижения
-    <small class="text-muted">
-      {{ status.earned }} из {{ status.achievements | length }}
-    </small>
-  </h6>
-  <h6 class="card-subtitle mb-2 text-muted">
-    Сможете ли Вы решить задачу всеми способами, известными <a class="text-decoration-none"
-      href="https://github.com/true-grue/kispython/blob/main/contrib/elm.ipynb">искусственной нейронной сети</a>?
-  </h6>
-  {% if status.achievements %}
-  {% for dto in status.achievements %}
-  <div class="callout callout-{{ 'success' if dto.active else 'default text-muted' }}">
-    <div>{{ dto.title }} {{ '✓' if dto.active else '' }}</div>
-    <small>{{ dto.description }}</small>
-  </div>
-  {% endfor %}
-  {% endif %}
-</div>
-{% endif %}
+
+{% include 'student/task_status.jinja' %}
+
 <div class="card m-auto mt-3 mb-5">
   <form class="card-body" action="{{ status.submission_url }}" method="POST">
     <h6 class="card-title fw-bold mb-0">Добавить новый ответ</h6>

--- a/webapp/templates/student/task.jinja
+++ b/webapp/templates/student/task.jinja
@@ -29,7 +29,9 @@
   </a>
 </div>
 
+<div id="task-status">
 {% include 'student/task_status.jinja' %}
+</div>
 
 <div class="card m-auto mt-3 mb-5">
   <form class="card-body" action="{{ status.submission_url }}" method="POST">

--- a/webapp/templates/student/task_status.jinja
+++ b/webapp/templates/student/task_status.jinja
@@ -1,0 +1,42 @@
+<div>
+  <h6 class="card-title fw-bold">
+    Состояние задачи
+  </h6>
+  <h6 class="card-subtitle mb-2 text-muted">
+    В данной секции Вы можете отслеживать состояние задания после отправки решения.
+  </h6>
+  {% if status.status == 4 %}
+  {% else %}
+  <div class="badge alert-{{ status.color }} mt-2 mb-2" style="font-size: inherit">
+    {{ status.name }}
+  </div>
+  {% if status.error_message is not none and status.error_message and (not registration or student) %}
+  <div>Подробные сведения об ошибке:</div>
+  <div class="text-muted mb-2" style="white-space: pre-wrap">{{ status.error_message | e }}</div>
+  {% else %}
+  <div class="mb-2"></div>
+  {% endif %}
+  {% endif %}
+</div>
+{% if status.show_achievements %}
+<div>
+  <h6 class="card-title fw-bold">
+    Разблокированные достижения
+    <small class="text-muted">
+      {{ status.earned }} из {{ status.achievements | length }}
+    </small>
+  </h6>
+  <h6 class="card-subtitle mb-2 text-muted">
+    Сможете ли Вы решить задачу всеми способами, известными <a class="text-decoration-none"
+      href="https://github.com/true-grue/kispython/blob/main/contrib/elm.ipynb">искусственной нейронной сети</a>?
+  </h6>
+  {% if status.achievements %}
+  {% for dto in status.achievements %}
+  <div class="callout callout-{{ 'success' if dto.active else 'default text-muted' }}">
+    <div>{{ dto.title }} {{ '✓' if dto.active else '' }}</div>
+    <small>{{ dto.description }}</small>
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>
+{% endif %}

--- a/webapp/views/student.py
+++ b/webapp/views/student.py
@@ -253,7 +253,7 @@ def task_status(student: Student | None, gid: int, vid: int, tid: int):
     if student and not student.teacher and student.group != gid:
         return redirect("/")
     status = statuses.get_task_status(gid, vid, tid)
-    if status.status not in [Status.Submitted, Status.CheckedSubmitted]:
+    if not status.is_submitted:
         return render_template(
             "student/task_status.jinja",
             registration=config.config.registration,

--- a/webapp/views/student.py
+++ b/webapp/views/student.py
@@ -14,7 +14,7 @@ from flask import redirect, render_template, request, send_from_directory
 
 from webapp.forms import StudentChangePasswordForm, StudentLoginForm, StudentMessageForm, StudentRegisterForm
 from webapp.managers import AppConfigManager, GroupManager, HomeManager, StatusManager, StudentManager
-from webapp.models import Student
+from webapp.models import Status, Student
 from webapp.repositories import AppDatabase
 from webapp.utils import authorize, get_exception_info, get_greeting_msg, get_real_ip, logout
 
@@ -243,6 +243,25 @@ def submit_task(student: Student | None, gid: int, vid: int, tid: int):
         form=form,
         student=student,
     )
+
+
+@blueprint.route('/group/<int:gid>/variant/<int:vid>/task/<int:tid>/status', methods=["GET"])
+@authorize(db.students)
+def task_status(student: Student | None, gid: int, vid: int, tid: int):
+    if config.config.registration and not student:
+        return redirect("/login")
+    if student and not student.teacher and student.group != gid:
+        return redirect("/")
+    status = statuses.get_task_status(gid, vid, tid)
+    if status.status not in [Status.Submitted, Status.CheckedSubmitted]:
+        return render_template(
+            "student/task_status.jinja",
+            registration=config.config.registration,
+            status=status,
+            student=student,
+        )
+    else:
+        return ('', 418)
 
 
 @blueprint.route("/files/task/<int:tid>/group/<int:gid>", methods=["GET"])

--- a/webapp/views/student.py
+++ b/webapp/views/student.py
@@ -232,14 +232,7 @@ def submit_task(student: Student | None, gid: int, vid: int, tid: int):
         session_id = request.cookies.get("anonymous_identifier")
         db.messages.submit_task(tid, vid, gid, form.code.data, ip, sid, session_id)
         db.statuses.submit_task(tid, vid, gid, form.code.data, ip)
-        return render_template(
-            "student/success.jinja",
-            status=status,
-            registration=config.config.registration,
-            group_rating=config.config.groups,
-            exam=config.config.exam,
-            student=student,
-        )
+        return redirect(f"/group/{gid}/variant/{vid}/task/{tid}")
     return render_template(
         "student/task.jinja",
         highlight=config.config.highlight_syntax,


### PR DESCRIPTION
# Демонстрация
https://github.com/user-attachments/assets/8b53fc13-e3ee-4f71-a501-400eed4902fb

# Как оно работает?
Фрагмент HTML со статусом задачи был выделен в отдельный шаблон student/task_status.jinja, student/task.jinja безусловно его включает в себя. Кроме того, этот статус теперь находится в div с id равным task-status. POST запрос на `/group/<int:gid>/variant/<int:vid>/task/<int:tid>/ws` при успешном отправлении задачи перенаправляет на себя же.

Была добавлена ручка `/group/<int:gid>/variant/<int:vid>/task/<int:tid>/ws` с WebSocket. При подключении он ждёт пока данная задача не будет проверена, после чего отправляет HTML с новым статусом задачи и закрывает сокет.

JS на `/group/<int:gid>/variant/<int:vid>/task/<int:tid>`, который добавляется на уровне шаблона только если задача проверяется, подключается к выше упомянутому WebSocket и заменяет содержимое `#task-status` на каждое пришедшее сообщение.

# Почему оно так работает?
Было 3 варианта решить эту задачу:
* Поллинг на стороне клиента - просто, чуть меньше нагружает сервер, возможно чуть больше тратит трафика, и мне вроде говорили так не делать
* SSE - не нужно подключать сторонние библиотеки, старше чем сами вебсокеты (вроде), проще тестировать из pytest, но данный функционал будет сложнее вынести в отдельный процесс, о чём будет ниже
* WebSocket - текущая реализация

Так как для последних двух способов необходимо держать "живой" запрос, которому необходимо занимать один из потоков у WSGI-сервера, придётся увеличить пул воркеров и потоков у каждого воркера, иначе эти долгоживущие запросы имеют вероятность повесить сервер. Для избежания этого в текущей реализации сервер закрывает сокет либо если задача не отправлена, либо как только она проверена.

В реализации с WS это проще вынести в отдельный процесс, а reverse-proxy вроде nginx будет распознавать запросы к этому WS и перенаправлять их на этот процесс. Это снизит нагрузку на основное приложение и избавит от необходимости увеличивать количество потоков.

# Что стоит изменить в будущем?
## Добавить PubSub
На данный момент сервер проверяет статус задачи простым поллингом в цикле без каких либо задержек. Можно либо добавить Redis/Valkey как ещё один сервис, либо поддерживать только PostgreSQL и использовать его аналогичные способности. SQLAlchemy в теории поддерживает похожий функционал, но он [не очень хорошо работает с multiprocessing](https://docs.sqlalchemy.org/en/20/core/event.html#events-and-multiprocessing), поэтому им не воспользовался.
## Тесты
Я также не нашёл способ тестировать WS из pytest, поэтому тесты не добавил, но `make coverage` мне говорит, что `/group/<int:gid>/variant/<int:vid>/task/<int:tid>` в целом не покрыт тестами, так что считаю своё решение чуточку более обоснованным (:
## Минимизация `static/js/autoreload.js`
Руками это не очень хорошо делать, поэтому надо придумать способ внедрить это в сборочную систему, который видимо сейчас тоже нет.